### PR TITLE
Attempt to `model.load` when new `belongsToMany`

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -345,7 +345,7 @@ Manager.prototype.setBelongsTo = function(model, key, value, relation) {
 Manager.prototype.setBelongsToMany = function(model, key, models, relation) {
   var existing = model.related(key);
 
-  return Promise.cast(existing.length ? existing : existing.fetch()).then(function() {
+  return Promise.cast(existing.length ? existing : model.load(key)).then(function() {
     return this.setCollection(existing, models);
   }.bind(this)).then(function(targets) {
     // Enforce attach/detach IDs

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -343,23 +343,21 @@ Manager.prototype.setBelongsTo = function(model, key, value, relation) {
 };
 
 Manager.prototype.setBelongsToMany = function(model, key, models, relation) {
-  var existing = model.related(key);
-
-  return Promise.cast(existing.length ? existing : model.load(key)).then(function() {
-    return this.setCollection(existing, models);
+  return Promise.cast(model.related(key).length ? model.related(key) : model.load(key)).then(function() {
+    return this.setCollection(model.related(key), models);
   }.bind(this)).then(function(targets) {
     // Enforce attach/detach IDs
-    existing.relatedData.parentId = model.id;
-    existing.relatedData.parentFk = model.id;
+    model.related(key).relatedData.parentId = model.id;
+    model.related(key).relatedData.parentFk = model.id;
 
     return targets.mapThen(function(target) {
-      if (!existing.findWhere({ id: target.id })) {
-        return existing.attach(target);
+      if (!model.related(key).findWhere({ id: target.id })) {
+        return model.related(key).attach(target);
       }
     }).then(function() {
-      return existing.mapThen(function(target) {
+      return model.related(key).mapThen(function(target) {
         if (!targets.findWhere({ id: target.id })) {
-          return existing.detach(target);
+          return model.related(key).detach(target);
         }
       });
     });


### PR DESCRIPTION
My attempt at fixing #1.  The hope was, for pre-loaded relationships, the deep model wouldn't have to be loaded again.  I may be wrong =/
