### PR TITLE
Fix Model.save() being called before scalar attributes are set

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -300,24 +300,37 @@ Manager.prototype.setModel = function(model, properties) {
       });
     }.bind(this));
   } else {
-    promises.push(function() {
-      return (model.isNew() || model.hasChanged()) ? model.save() : model;
+    promises.push(function () {
+      return model;
     });
   }
 
-  Object.keys(properties).forEach(function(key) {
-    var value     = properties[key];
-    var relation  = model[key] instanceof Function ? model[key].call(model) : null;
-    var type      = relation ? relation.relatedData.type : 'scalar';
-    var method    = 'set' + type.charAt(0).toUpperCase() + type.slice(1);
-    var setter    = this[method].bind(this);
+  function setProperties (propertyType) {
 
-    promises.push(function(result) {
-      return setter(result, key, value, relation).then(function() {
-        return result;
-      });
-    });
-  }.bind(this));
+    Object.keys(properties).forEach(function(key) {
+      var value     = properties[key];
+      var relation  = model[key] instanceof Function ? model[key].call(model) : null;
+      var type      = relation ? relation.relatedData.type : 'scalar';
+      var method    = 'set' + type.charAt(0).toUpperCase() + type.slice(1);
+      var setter    = this[method].bind(this);
+
+      if ((type === 'scalar' && propertyType === 'scalar') || (type !== 'scalar' && propertyType === 'related')) {
+        promises.push(function(result) {
+          return setter(result, key, value, relation).then(function() {
+            return result;
+          });
+        });
+      }
+    }.bind(this));
+  }
+
+  setProperties.bind(this)('scalar');
+
+  promises.push(function (result) {
+    return (result.isNew() || result.hasChanged()) ? result.save() : result;
+  });
+
+  setProperties.bind(this)('related');
 
   return Promise.reduce(promises, function(result, promise) {
     return promise(result);

--- a/test/manager.create.js
+++ b/test/manager.create.js
@@ -155,12 +155,33 @@ describe('manager', function() {
           );
 
           assert.equal(
-            JSON.stringify(actual.related('models').at(0).related('type').toJSON(), null, 2),
-            JSON.stringify(result.related('models').at(0).related('type').toJSON(), null, 2)
+            actual.related('models').at(0).related('type').id,
+            result.related('models').at(0).related('type').id
+          );
+
+          assert.equal(
+            actual.related('models').at(0).related('type').name,
+            result.related('models').at(0).related('type').name
           );
 
           done();
         });
+      });
+    });
+
+    it('should set scalar attributes before saving new models', function () {
+      var ValidatedModel = manager.get('model').extend({
+        initialize: function() {
+          this.on('saving', this.validateSave);
+        },
+
+        validateSave: function() {
+          assert(typeof this.get('name') === 'string', 'Model name must be a string, not ' + typeof this.get('name'));
+        }
+      });
+
+      return manager.create(ValidatedModel, { name: 'test' }).then(function(model) {
+        assert.equal('test', model.get('name'), 'Model should have a name of `test`, not `' + model.get('name') + '`');
       });
     });
   });


### PR DESCRIPTION
This fixes an issue in `Manager.prototype.setModel` where the scalar attributes of a newly-created model are not set before it is saved to the database. This is not a problem for normal usage because the model is saved again a moment later with all attributes set, but if the user has set up some kind of validation on save that requires attributes to be present, the first save will result in validation failing.

As a bonus this also results in fewer writes to the database since we aren't double-saving new records anymore.

See the added test for an example.