### PR TITLE
Remove deprecation warning about registry plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
-  - 4
-  - 5
-  - 6
+  - 8
+  - 10
+  - 12

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -37,8 +37,10 @@ Manager.prototype.initialize = function(bookshelf) {
   this.bookshelf  = bookshelf;
   this.knex       = this.bookshelf.knex;
   this.schema     = this.knex.schema;
-
-  bookshelf.plugin('registry');
+  
+  if (typeof bookshelf.collection !== 'function') {
+    bookshelf.plugin('registry');
+  }
 
   // Expose the Bookshelf Manager instance on the Bookshelf instance
   bookshelf.manager = this;
@@ -313,12 +315,12 @@ Manager.prototype.setBelongsToMany = Promise.method(function(model, key, models,
     existing.relatedData.parentFk = model.id;
 
     return targets.mapThen(function(target) {
-      if (!existing.findWhere({ id: target.id })) {
+      if (!existing.find(record => record.get('id') === target.id)) {
         return existing.attach(target, options);
       }
     }).then(function() {
       return existing.mapThen(function(target) {
-        if (!targets.findWhere({ id: target.id })) {
+        if (!targets.find(record => record.get('id') === target.id)) {
           return existing.detach(target, options);
         }
       });
@@ -367,7 +369,7 @@ Manager.prototype.setHasMany = Promise.method(function(model, key, models, relat
     });
 
     return existing.mapThen(function(target) {
-      if (!targets.findWhere({ id: target.id })) {
+      if (!targets.find(record => record.get('id') === target.id)) {
         return target.destroy(options);
       }
     });
@@ -394,7 +396,7 @@ Manager.prototype.setCollection = Promise.method(function(existing, models, opti
   models = models || [];
 
   return Promise.map(models, function(properties) {
-    var model = existing.findWhere({ id: properties.id }) || existing.model.forge();
+    var model = existing.find(record => record.get('id') === properties.id) || existing.model.forge();
 
     return this.save(model, properties, options);
   }.bind(this)).then(function(results) {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,5 @@
     "knex": "^0.12.1",
     "mocha": "^3.0.2",
     "sqlite3": "^4.2.0"
-  },
-  "peerDependencies": {
-    "bluebird": "3.x",
-    "bookshelf": "^0.10.0",
-    "knex": "^0.11.0 || ^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deep-diff": "^0.3.4",
     "knex": "^0.12.1",
     "mocha": "^3.0.2",
-    "sqlite3": "^3.1.4"
+    "sqlite3": "^4.2.0"
   },
   "peerDependencies": {
     "bluebird": "3.x",

--- a/test/manager.get.js
+++ b/test/manager.get.js
@@ -18,7 +18,7 @@ describe('manager', function() {
       describe('with a name', function() {
         describe('if the model hasn\'t been registered yet', function() {
           it('should throw an error', function() {
-            assert.throws(function() { manager.get('fake'); }, 'No model named `fake` has been registered and no model directory was specified');
+            assert.throws(function() { manager.get('fake'); }, /No model named `fake` has been registered and no model directory was specified/);
           });
         });
 

--- a/test/support/bootstrap.tables.js
+++ b/test/support/bootstrap.tables.js
@@ -1,84 +1,99 @@
 module.exports = function(manager) {
 
-  return manager.knex.transaction(function(trx) {
-    var schema = trx.schema;
-    return schema.createTableIfNotExists('cars', function(table) {
-      table.increments('id');
-      table.integer('color_id');
-      table.integer('dealer_id');
-      table.integer('model_id');
-      table.integer('quantity');
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('cars_features', function(table) {
+  return manager.knex.transaction(async function(trx) {
+    if (!(await trx.schema.hasTable('cars'))) {      
+      await trx.schema.createTable('cars', function(table) {
+        table.increments('id');
+        table.integer('color_id');
+        table.integer('dealer_id');
+        table.integer('model_id');
+        table.integer('quantity');
+      });
+    }
+   
+    if (!(await trx.schema.hasTable('cars_features'))) {
+      await trx.schema.createTable('cars_features', function(table) {
         table.increments('id');
         table.integer('car_id');
         table.integer('feature_id');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('colors', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('colors'))) {
+      await trx.schema.createTable('colors', function(table) {
         table.increments('id');
         table.string('name');
         table.string('hex_value');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('dealers', function(table) {
+    }
+    
+    
+    if (!(await trx.schema.hasTable('dealers'))) {
+      await trx.schema.createTable('dealers', function(table) {
         table.increments('id');
         table.integer('make_id');
         table.string('name');
         table.string('zip_code');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('features', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('features'))) {
+      await trx.schema.createTable('features', function(table) {
         table.increments('id');
         table.string('name');
         table.decimal('cost');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('makes', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('makes'))) {
+      await trx.schema.createTable('makes', function(table) {
         table.increments('id');
         table.string('name');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('models', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('models'))) {
+      await trx.schema.createTable('models', function(table) {
         table.increments('id');
         table.integer('make_id');
         table.integer('type_id');
         table.string('name');
         table.decimal('cost');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('models_specs', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('models_specs'))) {
+      await trx.schema.createTable('models_specs', function(table) {
         table.increments('id');
         table.integer('model_id');
         table.integer('spec_id');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('specs', function(table) {
+    }
+    
+    
+    if (!(await trx.schema.hasTable('specs'))) {
+      await trx.schema.createTable('specs', function(table) {
         table.increments('id');
         table.string('name');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('types', function(table) {
+    }
+   
+    if (!(await trx.schema.hasTable('types'))) {
+      await trx.schema.createTable('types', function(table) {
         table.increments('id');
         table.string('name');
       });
-    })
-    .then(function() {
-      return schema.createTableIfNotExists('titles', function(table) {
+    }
+    
+    
+    if (!(await trx.schema.hasTable('titles'))) {
+      await trx.schema.createTable('titles', function(table) {
         table.increments('id');
         table.integer('car_id');
         table.text('state');
         table.text('issue_date');
       });
-    });
+    }
+    
   });
 };


### PR DESCRIPTION
This removes the deprecation notice: 
```
Registry plugin was moved into core Bookshelf. You can now register models using `bookshelf.model()` and collections using `bookshelf.collection()` without having to call `.plugin('registry')`. Remove any `.plugin('registry')` calls to clear this message.
```
It also fixes deprecations for createTableIfNotExists in knex, and findWhere in bookshelf.

I tried to run the tests with upgraded bookshelf and knex versions, however one of the tests failed and I spent way too much time trying to figure out what was causing it.